### PR TITLE
[Update] Modifid error handling of MoveToTrashBox

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,9 +41,9 @@ func main() {
 	}
 
 	for _, path := range args {
-		ret := MoveToTrashBox(path)
-		if ret != 0 {
-			fmt.Println("go-trash: cannot move to trashbox: ", path)
+		err := MoveToTrashBox(path)
+		if err != nil {
+			fmt.Println("[Error] ", err)
 		}
 	}
 }

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -107,26 +107,23 @@ func convertTrashInfo(i Info) string {
 	return fmt.Sprintf("[Trash Info]\nPath=%s\nDeletionDate=%s\n", i.path, i.deletionDate.UTC().Format(time.RFC3339))
 }
 
-func MoveToTrashBox(path string) (ret int) {
+func MoveToTrashBox(path string) (err error) {
 	filename := filepath.Base(path)
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		fmt.Errorf("Failure to get absolute representation of path: %s", err)
-		return 1
+		return err
 	}
 
 	info := Info{abs, time.Now()}
 	user, err := user.Current()
 	if err != nil {
-		fmt.Errorf("Failure to get user's home directory: %s", err)
-		return 1
+		return err
 	}
 
 	trashBase := strings.Replace("~/.local/share/Trash", "~", user.HomeDir, 1)
 	err = os.WriteFile(trashBase+"/info/"+filename+".trashinfo", []byte(convertTrashInfo(info)), os.ModePerm)
 	if err != nil {
-		fmt.Errorf("Failure to writeFile source file: %s", err)
-		return 1
+		return err
 	}
 
 	// May not be able to move files or directories between different partitions
@@ -134,11 +131,10 @@ func MoveToTrashBox(path string) (ret int) {
 	// https://stackoverflow.com/questions/42392600/oserror-errno-18-invalid-cross-device-link
 	err = os.Rename(path, trashBase+"/files/"+filename)
 	if err != nil {
-		fmt.Errorf("Failure to rename source file: %s", err)
-		return 1
+		return err
 	}
 
-	return 0
+	return nil
 }
 
 func RestoreItem(filename string) (ret int) {


### PR DESCRIPTION
# Detail
When _SHFileOperation  is called, the error content is always  "The operation completed successfully."
So, I add function that call FormatMessage API to display correct errors.

# After
```
 .\go-trash.exe hoge
[Error]  no such file or directory
```