### PR TITLE
[Update] In Windows, improve to store in a specified path.

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,27 +9,33 @@ import (
 
 func main() {
 	var (
-		isList       bool
-		isHelp       bool
-		undeleteFile string
+		isList       = false
+		isHelp       = false
+		undeleteFile = ""
+		outputPath   = ""
 	)
 
 	getopt.Flag(&isList, 'l', "List trashed files")
 	getopt.Flag(&isHelp, 'h', "Show help")
 	getopt.Flag(&undeleteFile, 'u', "Restore files to original location", "File")
+	getopt.Flag(&outputPath, 'o', "Output file to location", "File")
 	getopt.Parse()
 	args := getopt.Args()
 
 	if len(undeleteFile) != 0 {
-		RestoreItem(undeleteFile)
+		err := RestoreItem(undeleteFile, outputPath)
+		if err != nil {
+			fmt.Println("go-trash: ", err)
+		}
 		os.Exit(0)
 	}
 
 	if isList == true {
 		fmt.Println("")
 		fmt.Println("# Trash Box #")
-		if PrintTrashBoxItems() != nil {
-			fmt.Println("go-trash: cannot print items in trashbox")
+		err := PrintTrashBoxItems()
+		if err != nil {
+			fmt.Println("go-trash: ", err)
 			os.Exit(1)
 		}
 		os.Exit(0)
@@ -43,7 +49,7 @@ func main() {
 	for _, path := range args {
 		err := MoveToTrashBox(path)
 		if err != nil {
-			fmt.Println("[Error] ", err)
+			fmt.Println("go-trash: ", err)
 		}
 	}
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -628,7 +628,7 @@ func RestoreItem(file string, outputPath string) error {
 			fmt.Printf("%d\t %s\t %d\t\t %s\t\n", i, v.dateDelete, v.size, v.path)
 		}
 
-		fmt.Printf("Which one do you restore? > ")
+		fmt.Printf("Which one do you want to restore[ID] ? > ")
 		scanner := bufio.NewScanner(os.Stdin)
 		scanner.Scan()
 		id, _ = strconv.Atoi(scanner.Text())

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -398,7 +398,7 @@ func getDateDelete(rbInternalFormat []byte) time.Time {
 	binary.Read(bytes.NewReader(rbInternalFormat[16:]), binary.LittleEndian, &dd)
 	// Convert NT time to Unix epoch
 	// Unix: 1/1/1970 00:00, Windows NT: 1/1/1601 00:00
-	return time.Unix((dd/10000000)-60*60*24*365*369, 0)
+	return time.Unix((dd/10000000)-11644473600, (dd%10000000)*100)
 }
 
 func getFileSize(rbInternalFormat []byte) int64 {


### PR DESCRIPTION
# Detail
I modify ResotreItem API to enable restoration to a specified path.

# Example
Note: `C:\Git\go-trash\testA.txt` and  `C:\Desktop\AAA.txt` are sample directory.
```
> go-trash.exe -u test -o AAA
ID       DateDeleted                     FileSize        Path
0        2024-04-12 23:57:03 +0900 JST   77              C:\Git\go-trash\test.txt
1        2024-04-12 23:56:13 +0900 JST   18              C:\Git\go-trash\testA.txt
Which one do you want to restore? > 1

Restore C:\Git\go-trash\testA.txt → C:\Desktop\AAA.txt
```